### PR TITLE
Reuse memo table object for encoder type registry

### DIFF
--- a/tests/test_quickle.py
+++ b/tests/test_quickle.py
@@ -587,6 +587,12 @@ def test_pickler_unpickler_registry_kwarg_errors():
     with pytest.raises(TypeError, match="registry must be a list or a dict"):
         quickle.Encoder(registry="bad")
 
+    with pytest.raises(TypeError, match="an integer is required"):
+        quickle.Encoder(registry={MyStruct: 1.0})
+
+    with pytest.raises(ValueError, match="registry values must be between"):
+        quickle.Encoder(registry={MyStruct: -1})
+
     with pytest.raises(TypeError, match="registry must be a list or a dict"):
         quickle.Decoder(registry="bad")
 
@@ -629,7 +635,7 @@ def test_pickle_struct_codes(code):
 
 def test_pickle_struct_code_out_of_range():
     x = MyStruct(1, 2)
-    with pytest.raises(ValueError, match="out of range"):
+    with pytest.raises(ValueError, match="registry values must be between"):
         quickle.dumps(x, registry={MyStruct: 2 ** 32})
 
 
@@ -741,7 +747,7 @@ def test_pickle_enum_code_out_of_range():
     class Fruit(enum.IntEnum):
         APPLE = 1
 
-    with pytest.raises(ValueError, match="out of range"):
+    with pytest.raises(ValueError, match="registry values must be between"):
         quickle.dumps(Fruit.APPLE, registry={Fruit: 2 ** 32})
 
 


### PR DESCRIPTION
The hashtable acting as a type registry:
- needs to be a map between python objects and positive `Py_ssize_t` values.
- is read only (after setup)
- doesn't need to support deletions
- only needs to support lookups by id)

This makes python dicts a bit overkill for our needs. Luckily the
existing `MemoTable` objects fit these needs perfectly.

This renames `MemoTable` to `LookupTable`, and updates the `Encoder` to
use `LookupTable` for the type registry.

This makes it slightly slower to create an `Encoder` (we do more work
upfront), with the benefit of serialization being slightly faster.
Another benefit is that since we iterate over the passed in `registry`
now, we can validate the arguments on init rather on calls to `dumps`,
providing slightly better error messages.