### PR TITLE
Reduce size of timedelta payload

### DIFF
--- a/tests/test_quickle.py
+++ b/tests/test_quickle.py
@@ -830,6 +830,8 @@ TIMEDELTA_MAX_DAYS = 999999999
         datetime.timedelta(days=TIMEDELTA_MAX_DAYS),
         datetime.timedelta(days=-TIMEDELTA_MAX_DAYS),
         datetime.timedelta(days=1234, seconds=56, microseconds=78),
+        datetime.timedelta(seconds=24 * 3600 - 1),
+        datetime.timedelta(microseconds=1000000 - 1),
     ],
 )
 def test_timedelta(x):


### PR DESCRIPTION
We don't need full 4-byte ints for all fields, saves 2 bytes per
timedelta.