### PR TITLE
Fix segfault on typeerror in quickle.loads

### DIFF
--- a/quickle.c
+++ b/quickle.c
@@ -2891,6 +2891,9 @@ Decoder_init_internal(DecoderObject *self, PyObject *registry)
     self->marks_allocated = 0;
     self->marks = NULL;
 
+    self->buffers = NULL;
+    self->buffer.buf = NULL;
+
     if (registry == NULL || registry == Py_None) {
         self->registry = NULL;
     }
@@ -4342,6 +4345,7 @@ Decoder_loads_internal(DecoderObject *self, PyObject *data, PyObject *buffers) {
 cleanup:
     if (self->buffer.buf != NULL) {
         PyBuffer_Release(&self->buffer);
+        self->buffer.buf = NULL;
         self->input_buffer = NULL;
     }
     Py_CLEAR(self->buffers);

--- a/tests/test_quickle.py
+++ b/tests/test_quickle.py
@@ -1,5 +1,6 @@
 import datetime
 import enum
+import gc
 import itertools
 import pickle
 import pickletools
@@ -963,3 +964,18 @@ def test_objects_with_only_one_refcount_arent_memoized():
     # 5 memoize codes, 1 for data and 1 for the tuple, 1 for each list
     assert s.count(pickle.MEMOIZE) == 5
     del a
+
+
+@pytest.mark.parametrize("use_decoder", [True, False])
+def test_loads_errors_wrong_type(use_decoder):
+    """Previously this would segfault on GC collect if using `quickle.loads` on
+    the wrong type"""
+    if use_decoder:
+        dec = quickle.Decoder()
+    else:
+        dec = quickle
+
+    for i in range(3):
+        with pytest.raises(TypeError):
+            dec.loads(1)
+        gc.collect()


### PR DESCRIPTION
Previously if non-bytes were passed in to `quickle.loads`, a segfault
would occur during collection since `buffers`/`buffer` were never
initialized. We now init to `NULL` and add a test for this.