### PR TITLE
Update known types for struct defaults

### DIFF
--- a/quickle.c
+++ b/quickle.c
@@ -625,8 +625,9 @@ maybe_deepcopy_default(PyObject *obj, int *is_copy) {
     /* Known non-collection types */
     if (obj == Py_None || obj == Py_False || obj == Py_True ||
         type == &PyLong_Type || type == &PyFloat_Type ||
-        type == &PyBytes_Type || type == &PyUnicode_Type ||
-        type == &PyByteArray_Type || type == &PyPickleBuffer_Type
+        type == &PyComplex_Type || type == &PyBytes_Type ||
+        type == &PyUnicode_Type || type == &PyByteArray_Type ||
+        type == &PyPickleBuffer_Type
     ) {
         return obj;
     }
@@ -634,6 +635,13 @@ maybe_deepcopy_default(PyObject *obj, int *is_copy) {
         return obj;
     }
     else if (type == &PyFrozenSet_Type && PySet_GET_SIZE(obj) == 0) {
+        return obj;
+    }
+    else if (PyDelta_CheckExact(obj) || PyDateTime_CheckExact(obj) ||
+             PyTime_CheckExact(obj) || PyDate_CheckExact(obj)) {
+        return obj;
+    }
+    else if (PyType_IsSubtype(type, quickle_get_global_state()->EnumType)) {
         return obj;
     }
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1,4 +1,6 @@
+import enum
 import copy
+import datetime
 import gc
 import inspect
 import pickle
@@ -8,6 +10,11 @@ import pytest
 
 import quickle
 from quickle import Struct, PickleBuffer
+
+
+class Fruit(enum.IntEnum):
+    APPLE = 1
+    BANANA = 2
 
 
 def as_tuple(x):
@@ -471,12 +478,18 @@ def test_struct_compare_errors():
         True,
         1,
         2.0,
+        1.5 + 2.32j,
         b"test",
         "test",
         bytearray(b"test"),
         PickleBuffer(b"test"),
         (),
         frozenset(),
+        Fruit.APPLE,
+        datetime.time(1),
+        datetime.date.today(),
+        datetime.timedelta(seconds=2),
+        datetime.datetime.now(),
     ],
 )
 def test_struct_immutable_defaults_use_instance(default):


### PR DESCRIPTION
There's a fast path for known types used as default values for Struct
type fields. This updates the set to include `complex`, `enum.Enum`, and
`datetime` types.

Fixes #51.