### PR TITLE
Support timezone objects

### DIFF
--- a/tests/test_quickle.py
+++ b/tests/test_quickle.py
@@ -874,6 +874,7 @@ def test_loads_date_out_of_range():
         datetime.time(hour=23, minute=59, second=59, microsecond=999999, fold=0),
         datetime.time(hour=23, minute=59, second=59, microsecond=999999, fold=1),
         datetime.time(hour=5, tzinfo=datetime.timezone.utc),
+        datetime.time(hour=5, tzinfo=datetime.timezone(datetime.timedelta(0, 1, 2))),
     ],
 )
 def test_time(x):
@@ -907,6 +908,7 @@ def test_time(x):
             fold=1,
         ),
         datetime.datetime.now(datetime.timezone.utc),
+        datetime.datetime.now(datetime.timezone(datetime.timedelta(0, 1, 2))),
     ],
 )
 def test_datetime(x):
@@ -919,6 +921,24 @@ def test_timezone_utc():
     s = quickle.dumps(datetime.timezone.utc)
     x = quickle.loads(s)
     assert x == datetime.timezone.utc
+
+
+@pytest.mark.parametrize(
+    "offset",
+    [
+        datetime.timedelta(hours=23, minutes=59, seconds=59, microseconds=999999),
+        datetime.timedelta(hours=1, minutes=2, seconds=3, microseconds=4),
+        datetime.timedelta(microseconds=1),
+        datetime.timedelta(microseconds=-1),
+        datetime.timedelta(hours=-1, minutes=-2, seconds=-3, microseconds=-4),
+        datetime.timedelta(hours=-23, minutes=-59, seconds=-59, microseconds=-999999),
+    ],
+)
+def test_timezone(offset):
+    x = datetime.timezone(offset)
+    s = quickle.dumps(x)
+    x2 = quickle.loads(s)
+    assert x == x2
 
 
 def test_objects_with_only_one_refcount_arent_memoized():

--- a/tests/test_quickle.py
+++ b/tests/test_quickle.py
@@ -873,18 +873,13 @@ def test_loads_date_out_of_range():
         datetime.time(hour=5, minute=30, second=25),
         datetime.time(hour=23, minute=59, second=59, microsecond=999999, fold=0),
         datetime.time(hour=23, minute=59, second=59, microsecond=999999, fold=1),
+        datetime.time(hour=5, tzinfo=datetime.timezone.utc),
     ],
 )
 def test_time(x):
     s = quickle.dumps(x)
     x2 = quickle.loads(s)
     assert x == x2
-
-
-def test_time_with_timezone_errors():
-    d = datetime.time(hour=5, tzinfo=datetime.timezone.utc)
-    with pytest.raises(quickle.EncodingError, match="timezone"):
-        quickle.dumps(d)
 
 
 @pytest.mark.parametrize(
@@ -911,18 +906,13 @@ def test_time_with_timezone_errors():
             microsecond=999999,
             fold=1,
         ),
+        datetime.datetime.now(datetime.timezone.utc),
     ],
 )
 def test_datetime(x):
     s = quickle.dumps(x)
     x2 = quickle.loads(s)
     assert x == x2
-
-
-def test_datetime_with_timezone_errors():
-    d = datetime.datetime.now(datetime.timezone.utc)
-    with pytest.raises(quickle.EncodingError, match="timezone"):
-        quickle.dumps(d)
 
 
 def test_timezone_utc():

--- a/tests/test_quickle.py
+++ b/tests/test_quickle.py
@@ -925,6 +925,12 @@ def test_datetime_with_timezone_errors():
         quickle.dumps(d)
 
 
+def test_timezone_utc():
+    s = quickle.dumps(datetime.timezone.utc)
+    x = quickle.loads(s)
+    assert x == datetime.timezone.utc
+
+
 def test_objects_with_only_one_refcount_arent_memoized():
     class Test(quickle.Struct):
         x: list


### PR DESCRIPTION
Adds support for timezone aware `datetime` and `time` objects. For now, only `datetime.timezone` and `datetime.timezone.utc` objects are supported for `tzinfo`.