### PR TITLE
Add new types to docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -95,6 +95,8 @@ Quickle currently supports serializing the following types:
 - `datetime.time`
 - `datetime.datetime`
 - `datetime.timedelta`
+- `datetime.timezone`
+- `zoneinfo.ZoneInfo`
 - `enum.Enum`
 - `quickle.PickleBuffer`
 - `quickle.Struct`


### PR DESCRIPTION
Now supporting:
- datetime.timezone
- zoneinfo.ZoneInfo